### PR TITLE
FIX: default urllib user agent rejection

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,5 @@
+[flake8]
+exclude = .git,__pycache__,build,dist
+max-line-length = 88
+select = C,E,F,W,B,B950
+extend-ignore = E203, E501, E226, W503, W504

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    -   id: no-commit-to-branch
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-ast
+    -   id: check-case-conflict
+    -   id: check-json
+    -   id: check-merge-conflict
+    -   id: check-symlinks
+    -   id: check-xml
+    -   id: check-yaml
+    -   id: debug-statements
+
+-   repo: https://github.com/pycqa/flake8.git
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort


### PR DESCRIPTION
## Context

Closes #16 
Supersedes #15 as adding in another library should not be our first pass solution. If this ends up being insufficient, we can revisit.

## Changes

* Adds pre-commit and flake8 settings
* Allows for environment-level user agent configuration
* Defaults user agent to a simple Mozilla/5.0 which anecdotally is sufficient to avoid Beckhoff's rejection of the download request

## Testing

Working locally (off-SLAC campus) with all 3 PLC models.